### PR TITLE
Fixes #9 by adding vertical alignment

### DIFF
--- a/pref/CHANGELOG.md
+++ b/pref/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.0
+
+- Option to align slider below the title and trailing for wider control
+[MrCsabaToth](https://github.com/MrCsabaToth)
+
 ## 2.3.0
 
 - Setting a value to `null` will remove it from the backend service
@@ -11,7 +16,7 @@
 
 ## 2.1.0
 
-- Expose inputFormatters in PrefText [tsonnen]
+- Expose inputFormatters in PrefText [tsonnen](https://github.com/tsonnen)
 
 ## 2.0.2
 

--- a/pref/example/lib/main.dart
+++ b/pref/example/lib/main.dart
@@ -42,6 +42,7 @@ Future<void> main() async {
     'android_multilistpref_c': true,
     'exp_showos': false,
     'age': 65,
+    'weight': 60,
   });
 
   runApp(MyApp(service));
@@ -212,6 +213,15 @@ class _MyHomePageState extends State<MyHomePage> {
             trailing: (num v) => SizedBox(width: 50, child: Text('I\'m $v')),
             min: 10,
             max: 90,
+          ),
+          PrefSlider<int>(
+            title: Text('Person weight (metric)'),
+            subtitle: Text('Demonstrating a long title and wide scale slider'),
+            pref: 'weight',
+            trailing: (num v) => Text('Weighs $v kilogram'),
+            min: 10,
+            max: 250,
+            direction: Axis.vertical,
           ),
           PrefLabel(
             title: Text(

--- a/pref/lib/src/slider.dart
+++ b/pref/lib/src/slider.dart
@@ -24,6 +24,7 @@ class PrefSlider<T extends num> extends StatefulWidget {
     this.divisions,
     this.label,
     this.trailing,
+    this.direction = Axis.horizontal,
   }) : super(key: key);
 
   final Widget? title;
@@ -47,6 +48,8 @@ class PrefSlider<T extends num> extends StatefulWidget {
   final String Function(T value)? label;
 
   final Widget Function(T value)? trailing;
+
+  final Axis direction;
 
   @override
   _PrefSliderState createState() => _PrefSliderState<T>();
@@ -117,23 +120,43 @@ class _PrefSliderState<T extends num> extends State<PrefSlider> {
     final trailing = widget.trailing != null && value != null
         ? widget.trailing!(value)
         : null;
+    final slider = Slider(
+      label: label,
+      value: doubleValue,
+      onChanged: _onChange,
+      min: min,
+      max: max,
+      divisions: widget.divisions,
+    );
+
+    if (widget.direction == Axis.horizontal) {
+      return ListTile(
+        subtitle: widget.subtitle,
+        trailing: trailing,
+        title: Row(
+          children: [
+            if (widget.title != null) widget.title!,
+            Expanded(child: slider),
+          ],
+        ),
+      );
+    }
 
     return ListTile(
       subtitle: widget.subtitle,
-      trailing: trailing,
-      title: Row(
+      title: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          if (widget.title != null) widget.title!,
-          Expanded(
-            child: Slider(
-              label: label,
-              value: doubleValue,
-              onChanged: _onChange,
-              min: min,
-              max: max,
-              divisions: widget.divisions,
+          if (widget.title != null || trailing != null)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                if (widget.title != null) widget.title!,
+                if (trailing != null) trailing,
+              ],
             ),
-          )
+          slider,
         ],
       ),
     );

--- a/pref/pubspec.yaml
+++ b/pref/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/DavBfr/flutter_pref/tree/master/pref
 repository: https://github.com/DavBfr/flutter_pref
 issue_tracker: https://github.com/DavBfr/flutter_pref/issues
 author: David PHAM-VAN <dev.nfet.net@gmail.com>
-version: 2.3.0
+version: 2.4.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
The title and the value labeling (previously trailing) stays in line. The slider is aligned below them if the direction is Axis.vertical. The default direction stays horizontal preserving the existing scrollbars. The build code was different enough that there are two larger statements. There's also an example added. There wasn't any code documentation so I haven't fiddled with anything on that note.
I tested the cases when the title is empty, or the value labeling is empty: in that case whichever is present it is aligned to the left.