### PR TITLE
Fixed incorrect method being used to store string lists

### DIFF
--- a/pref/lib/src/service/shared_preferences.dart
+++ b/pref/lib/src/service/shared_preferences.dart
@@ -52,7 +52,7 @@ class PrefServiceShared extends BasePrefService {
       }
     } else if (val is List<String>) {
       if (await sharedPreferences.setStringList('$prefix$key', val)) {
-        return super.set<T>(key, val);
+        return super.put<T>(key, val);
       }
     }
     return false;


### PR DESCRIPTION
This fixes an loop where a string list specified in `defaults` ends up trying to set itself infinitely. Whoops!